### PR TITLE
CI: Verify support on Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,10 @@ jobs:
           "macos-12",
           "macos-latest",
         ]
-        python-version: ["3.7", "3.11", "3.12"]
+        python-version: [
+          "3.7",
+          "3.13",
+        ]
 
         # Doesn't work on macOS (ARM) with older versions of Python.
         exclude:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: SQL",
   "Topic :: Adaptive Technologies",


### PR DESCRIPTION
## About
[Python 3.13.0](https://www.python.org/downloads/release/python-3130/) has been released on Oct. 7, 2024. This PR intends to add CI verification.

## References
- https://github.com/crate/crate-python/pull/653
- https://github.com/crate/sqlalchemy-cratedb/pull/167
