### PR TITLE
Project: Remove support for PyPy from package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
-  "Programming Language :: Python :: Implementation :: PyPy",
   "Programming Language :: SQL",
   "Topic :: Adaptive Technologies",
   "Topic :: Communications",


### PR DESCRIPTION
## About
Because pytest-cratedb depends on cr8, which depends on asyncpg, needing a C compiler, this package will probably never work on PyPy.
