### PR TITLE
CI: Use macOS 13, macOS 12 has been deprecated.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [
           "ubuntu-22.04",
-          "macos-12",
+          "macos-13",
           "macos-latest",
         ]
         python-version: [


### PR DESCRIPTION
## About
What the title says.

## References
- https://github.com/actions/runner-images/issues/10721
- https://github.com/actions/runner-images/issues/9741
