### PR TITLE
Chore: Relax versions of tool dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,9 +78,9 @@ dependencies = [
 optional-dependencies.develop = [
   "mypy<1.16",
   "poethepoet<1",
-  "pyproject-fmt<2.6",
+  "pyproject-fmt<3",
   "ruff<0.12",
-  "validate-pyproject<0.24",
+  "validate-pyproject<1",
 ]
 optional-dependencies.release = [
   "build<2",


### PR DESCRIPTION
`pyproject-fmt` and `validate-pyproject` are considered to be stable enough to not cause too much havoc. The adjustment will lead to less Dependabot traffic.

If you don't agree with this and similar patches, please let me know.

/cc @surister, @kneth 